### PR TITLE
Rename devicetree bindings with the suffix catie

### DIFF
--- a/drivers/rtc/microcrystal/rv8803/Kconfig
+++ b/drivers/rtc/microcrystal/rv8803/Kconfig
@@ -6,7 +6,7 @@
 menuconfig RV8803
     bool "RTC RV-8803 peripheral"
     default y
-    depends on DT_HAS_MICROCRYSTAL_RV8803_ENABLED
+    depends on DT_HAS_MICROCRYSTAL_RV8803_CATIE_ENABLED
     select I2C
     help
       Enable driver for MICRO CRYSTAL RV-8803 smt real-time clock module on i2c-bus
@@ -23,7 +23,7 @@ if RV8803
     bool "Enable RTC Interface"
     default y
     depends on RV8803
-    depends on DT_HAS_MICROCRYSTAL_RV8803_RTC_ENABLED
+    depends on DT_HAS_MICROCRYSTAL_RV8803_RTC_CATIE_ENABLED
     help
       Enable real-time clock interface.
 
@@ -31,7 +31,7 @@ if RV8803
     bool "Enable COUNTER Interface"
     default y
     depends on RV8803
-    depends on DT_HAS_MICROCRYSTAL_RV8803_CNT_ENABLED
+    depends on DT_HAS_MICROCRYSTAL_RV8803_CNT_CATIE_ENABLED
     help
       Enable counter interface.
 
@@ -39,7 +39,7 @@ if RV8803
     bool "Enable Clock Control Interface"
     default y
     depends on RV8803
-    depends on DT_HAS_MICROCRYSTAL_RV8803_CLK_ENABLED
+    depends on DT_HAS_MICROCRYSTAL_RV8803_CLK_CATIE_ENABLED
     help
       Enable Clock Control Interface.
 endif # RV8803

--- a/drivers/rtc/microcrystal/rv8803/rv8803.c
+++ b/drivers/rtc/microcrystal/rv8803/rv8803.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT microcrystal_rv8803
+#define DT_DRV_COMPAT microcrystal_rv8803_catie
 
 #include <zephyr/logging/log.h>
 

--- a/drivers/rtc/microcrystal/rv8803/rv8803_clk.c
+++ b/drivers/rtc/microcrystal/rv8803/rv8803_clk.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT microcrystal_rv8803_clk
+#define DT_DRV_COMPAT microcrystal_rv8803_clk_catie
 
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/logging/log.h>

--- a/drivers/rtc/microcrystal/rv8803/rv8803_cnt.c
+++ b/drivers/rtc/microcrystal/rv8803/rv8803_cnt.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT microcrystal_rv8803_cnt
+#define DT_DRV_COMPAT microcrystal_rv8803_cnt_catie
 
 #include <zephyr/drivers/counter.h>
 #include <zephyr/logging/log.h>

--- a/drivers/rtc/microcrystal/rv8803/rv8803_rtc.c
+++ b/drivers/rtc/microcrystal/rv8803/rv8803_rtc.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT microcrystal_rv8803_rtc
+#define DT_DRV_COMPAT microcrystal_rv8803_rtc_catie
 
 #include <zephyr/drivers/rtc.h>
 #include <zephyr/sys/util.h>

--- a/dts/bindings/rtc/microcrystal,rv8803-catie.yaml
+++ b/dts/bindings/rtc/microcrystal,rv8803-catie.yaml
@@ -3,7 +3,7 @@
 
 description: Micro Crystal AG RV-8803.
 
-compatible: "microcrystal,rv8803"
+compatible: "microcrystal,rv8803-catie"
 
 on-bus: i2c
 

--- a/dts/bindings/rtc/microcrystal,rv8803-clk-catie.yaml
+++ b/dts/bindings/rtc/microcrystal,rv8803-clk-catie.yaml
@@ -3,7 +3,7 @@
 
 description: Micro Crystal AG RV-8803 CLK.
 
-compatible: "microcrystal,rv8803-clk"
+compatible: "microcrystal,rv8803-clk-catie"
 
 include:
   - name: clock-controller.yaml

--- a/dts/bindings/rtc/microcrystal,rv8803-cnt-catie.yaml
+++ b/dts/bindings/rtc/microcrystal,rv8803-cnt-catie.yaml
@@ -3,7 +3,7 @@
 
 description: Micro Crystal AG RV-8803 CNT.
 
-compatible: "microcrystal,rv8803-cnt"
+compatible: "microcrystal,rv8803-cnt-catie"
 
 include:
   - name: base.yaml

--- a/dts/bindings/rtc/microcrystal,rv8803-rtc-catie.yaml
+++ b/dts/bindings/rtc/microcrystal,rv8803-rtc-catie.yaml
@@ -3,7 +3,7 @@
 
 description: Micro Crystal AG RV-8803 RTC.
 
-compatible: "microcrystal,rv8803-rtc"
+compatible: "microcrystal,rv8803-rtc-catie"
 
 include:
   - name: rtc-device.yaml

--- a/samples/app.overlay
+++ b/samples/app.overlay
@@ -19,21 +19,21 @@
 	status = "okay";
 
 	rv88030: rv8803@32 {
-		compatible = "microcrystal,rv8803";
+		compatible = "microcrystal,rv8803-catie";
 		reg = <0x32>;
 		irq-gpios = <&sixtron_connector DIO2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 
 		rv88030_rtc: rv8803-rtc {
-			compatible = "microcrystal,rv8803-rtc";
+			compatible = "microcrystal,rv8803-rtc-catie";
 		};
 
 		rv88030_cnt: rv8803-cnt {
-			compatible = "microcrystal,rv8803-cnt";
+			compatible = "microcrystal,rv8803-cnt-catie";
 			frequency = "1";
 		};
 
 		rv88030_clk: rv8803-clk {
-			compatible = "microcrystal,rv8803-clk";
+			compatible = "microcrystal,rv8803-clk-catie";
 			#clock-cells = <0>;
 		};
 	};


### PR DESCRIPTION
This pull request updates the Micro Crystal RV-8803 RTC driver and related files to use a new naming (`-catie` suffix) for device compatibility strings. This component is already supported in Zephyr 4.1.0 ([RV8803 driver](https://github.com/zephyrproject-rtos/zephyr/blob/v4.1.0/drivers/rtc/rtc_rv8803.c)), but with less functionality. I propose to add a suffix to have the 2 drivers, the choice will be made in the device tree.

### Updates to Compatibility Strings

* **Kconfig dependencies**: Updated `depends on` conditions in `drivers/rtc/microcrystal/rv8803/Kconfig` to use the new compatibility strings with the `-catie` suffix.
* **Driver source files**: Updated `DT_DRV_COMPAT` macros in `rv8803.c`, `rv8803_clk.c`, `rv8803_cnt.c`, and `rv8803_rtc.c` to use the new name.

### Changes to Device Tree Bindings

* **Renamed YAML files**: Renamed device tree binding files to include the `-catie` suffix (e.g., `microcrystal,rv8803.yaml` to `microcrystal,rv8803-catie.yaml`) and updated the `compatible` property accordingly. 

### Updates to Sample Overlay

* **Overlay file**: Updated the `compatible` strings in `samples/app.overlay` to match the new naming for the main device and its subcomponents (RTC, CNT, CLK).